### PR TITLE
[IOPS-75] onprem tool add

### DIFF
--- a/containerd_config.toml
+++ b/containerd_config.toml
@@ -1,0 +1,48 @@
+version = 2
+root = "/var/lib/containerd"
+state = "/run/containerd"
+oom_score = 0
+
+[grpc]
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+
+[debug]
+  level = "info"
+
+[metrics]
+  address = ""
+  grpc_histogram = false
+
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    sandbox_image = "registry.k8s.io/pause:3.9"
+    max_container_log_line_size = -1
+    enable_unprivileged_ports = false
+    enable_unprivileged_icmp = false
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      default_runtime_name = "nvidia"
+      snapshotter = "overlayfs"
+      discard_unpacked_layers = true
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
+            privileged_without_host_devices = false
+            runtime_engine = ""
+            runtime_root = ""
+            runtime_type = "io.containerd.runc.v1"
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
+            BinaryName = "/usr/bin/nvidia-container-runtime"
+            SystemdCgroup = true
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v2"
+          runtime_engine = ""
+          runtime_root = ""
+          base_runtime_spec = "/etc/containerd/cri-base.json"
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            systemdCgroup = true
+            binaryName = "/usr/local/bin/runc"
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+          endpoint = ["https://registry-1.docker.io"]

--- a/gpu_containerd.yaml
+++ b/gpu_containerd.yaml
@@ -1,0 +1,45 @@
+---
+- name: Install NVIDIA Container Toolkit and update config.toml
+  hosts: all
+  become: yes  # Required to gain root privileges
+  tasks:
+    - name: Add NVIDIA GPG key
+      ansible.builtin.shell: |
+        curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --batch --yes --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+      ignore_errors: yes
+
+    - name: Add NVIDIA repository
+      ansible.builtin.shell: |
+        curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+        sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+        sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+
+    - name: Enable experimental features in the NVIDIA repository
+      ansible.builtin.lineinfile:
+        path: /etc/apt/sources.list.d/nvidia-container-toolkit.list
+        regexp: '^#.*experimental'
+        line: 'deb [arch=amd64 signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://nvidia.github.io/libnvidia-container/experimental/ubuntu18.04/$(ARCH) /'
+        backrefs: yes
+
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: yes
+
+    - name: Install NVIDIA container toolkit
+      ansible.builtin.apt:
+        name: nvidia-container-toolkit
+        state: present
+
+    - name: Copy containerd configuration file
+      ansible.builtin.copy:
+        src: ./containerd_config.toml
+        dest: /etc/containerd/config.toml
+        owner: root
+        group: root
+        mode: '0600'
+    - name: Restart containerd
+      ansible.builtin.systemd:
+        name: containerd
+        state: restarted     
+        daemon_reload: yes
+

--- a/install_aws_cli_v2.yaml
+++ b/install_aws_cli_v2.yaml
@@ -1,0 +1,45 @@
+---
+- name: Install AWS CLI v2, rsync, and copy .aws directory
+  hosts: all
+  become: yes
+  tasks:
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: yes
+        cache_valid_time: 3600  # Cache is considered valid for 1 hour
+
+    - name: Install rsync on Ubuntu using apt-get
+      command: apt-get -y install rsync
+
+    - name: Download AWS CLI v2
+      get_url:
+        url: https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip
+        dest: /tmp/awscliv2.zip
+        mode: '0644'
+
+    - name: Unzip AWS CLI v2 installer
+      ansible.builtin.unarchive:
+        src: /tmp/awscliv2.zip
+        dest: /tmp
+        remote_src: yes
+
+    - name: Run the AWS CLI v2 installer with update option
+      command: /tmp/aws/install --update
+
+    - name: Ensure .aws directory exists
+      file:
+        path: /root/.aws
+        state: directory
+        mode: '0755'
+
+    - name: Copy .aws directory to remote
+      synchronize:
+        src: ~/.aws/
+        dest: /root/.aws/
+        mode: push
+        recursive: yes
+   
+    - name: Install iscsiadm install
+      command: apt-get -y install open-iscsi
+    - name: install nfs
+      command: apt-get install -y nfs-common

--- a/iscsi.yml
+++ b/iscsi.yml
@@ -1,0 +1,24 @@
+- name: Copy iSCSI configuration files to all worker nodes
+  hosts: all
+  become: yes
+  tasks:
+    - name: Install iscsiadm install
+      command: apt-get -y install open-iscsi
+    - name: install nfs
+      command: apt-get install -y nfs-common
+    - name: Copy /etc/iscsi/initiatorname.iscsi to workers
+      ansible.builtin.copy:
+        src: /etc/iscsi/initiatorname.iscsi
+        dest: /etc/iscsi/initiatorname.iscsi
+        owner: root
+        group: root
+        mode: '0644'
+
+    - name: Copy /etc/iscsi/iscsid.conf to workers
+      ansible.builtin.copy:
+        src: /etc/iscsi/iscsid.conf
+        dest: /etc/iscsi/iscsid.conf
+        owner: root
+        group: root
+        mode: '0644'
+

--- a/update_dns.yml
+++ b/update_dns.yml
@@ -1,0 +1,15 @@
+---
+- name: Update DNS settings in systemd-resolved
+  hosts: all
+  become: yes  # 관리자 권한으로 실행
+  tasks:
+    - name: Insert DNS settings under [Resolve] section
+      lineinfile:
+        path: /etc/systemd/resolved.conf
+        insertafter: '^\[Resolve\]$'  # [Resolve] 섹션을 찾는 정규 표현식
+        line: 'DNS=169.254.25.10 10.0.0.1'
+        state: present
+    - name: Restart systemd-resolved service
+      systemd:
+        name: systemd-resolved
+        state: restarted


### PR DESCRIPTION
onprem에서 사용하는 도구들에 대해서 ansible playbook을 올립니다.

추가한 내용
- GPU 관련
  - GPU 를 사용하기 위해서는 nvidia container toolkit이 필요합니다. 해당 Tool 설치
  - GPU를 k8s에서 사용하기 위해서 containerd의 설정을 잡아줘야합니다. container_config.toml 파일을 GPU를 사용하는 모든 노드에 적용했습니다. 

- iscsi
  - iscsi를 사용하기 위해서 필요한 설정들을 설치하고 적용합니다.

- dns설정을 변경하여 nameserver에 gateway 서버인 10.0.0.1 을 추가해줘서 localdns가 무한 루프를 돌지 않도록 설정해줍니다.